### PR TITLE
Set application root in index.php

### DIFF
--- a/app/src/Action/HomepageFactory.php
+++ b/app/src/Action/HomepageFactory.php
@@ -14,7 +14,7 @@ class HomepageFactory
 {
     public static function factory(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
-        $action = new Homepage(new Template(__DIR__ . '/../../template'));
+        $action = new Homepage(new Template('app/template'));
         return $action($request, $response, $next);
     }
 }

--- a/app/src/Action/PageFactory.php
+++ b/app/src/Action/PageFactory.php
@@ -14,7 +14,7 @@ class PageFactory
 {
     public static function factory(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
-        $action = new Page(new Template(__DIR__ . '/../../template'));
+        $action = new Page(new Template('app/template'));
         return $action($request, $response, $next);
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -6,14 +6,20 @@
  * @author Enrico Zimuel (enrico@zend.com)
  */
 
+/**
+ * This makes our life easier when dealing with paths. Everything is relative
+ * to the application root now.
+ */
+chdir(dirname(__DIR__));
+
 use Zend\Stratigility\MiddlewarePipe;
 use Zend\Stratigility\Dispatch\MiddlewareDispatch;
 use Zend\Diactoros\Server;
 
-require '../vendor/autoload.php';
+require 'vendor/autoload.php';
 
 $app = new MiddlewarePipe();
-$app->pipe('/', MiddlewareDispatch::factory(require '../app/config/route.php'));
+$app->pipe('/', MiddlewareDispatch::factory(require 'app/config/route.php'));
 
 $server = Server::createServer($app, $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES);
 $server->listen();


### PR DESCRIPTION
Changes the `cwd` to be the application root to align it with the zend-skeleton and because it makes it really easier to deal with relative pathes. 
IMO the template set up looks nicer now.
